### PR TITLE
all: upgrade to golangci-lint v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - deadcode
     - depguard
     - dupl
     - errcheck
@@ -34,22 +33,22 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - thelper
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 
 linters-settings:
   depguard:
-    list-type: whitelist
-    packages:
-      - github.com/mmcloughlin/md4
+    rules:
+      main:
+        allow:
+          - github.com/mmcloughlin/md4
+          - $gostd
 
 issues:
   exclude-use-default: false

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Install golangci-lint
-golangci_lint_version='v1.42.0'
+golangci_lint_version='v1.55.2'
 golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
 curl -sfL "${golangci_install_script}" | sh -s -- -b "$GOPATH/bin" "${golangci_lint_version}"
 


### PR DESCRIPTION
Upgrade `golangci-lint` to address a bug triggered since Go 1.21.5.

See: golangci/golangci-lint#3718
See: golang/go#64592
